### PR TITLE
Fix Sargo API 28

### DIFF
--- a/sargo/config.json
+++ b/sargo/config.json
@@ -270,6 +270,7 @@
         "libprotobuf-cpp-full",
         "libprotobuf-cpp-full-rtti"
       ],
+      "product-bytecode": [],
       "new-modules": [],
       "dep-dso": [],
       "BoardConfigVendor": [],


### PR DESCRIPTION
This PR fixes downloads of Sargo with API 28. Without it execute-all.sh fails with:

`jq: error (at /home/ricardo/veniam/android-prepare-vendor/sargo/config.json:532): Cannot iterate over null (null)
[-] json raw string array parse failed
`