### PR TITLE
Use HTTP 1.1 to download images

### DIFF
--- a/scripts/download-nexus-image.sh
+++ b/scripts/download-nexus-image.sh
@@ -170,6 +170,6 @@ fi
 
 echo "[*] Downloading image from '$url'"
 outFile=$OUTPUT_DIR/$(basename "$url")
-curl -L -C - -o "$outFile" "$url"
+curl --http1.1 -L -C - -o "$outFile" "$url"
 
 abort 0


### PR DESCRIPTION
Workaround for the "curl: (92) HTTP/2 stream 0 was not closed cleanly: PROTOCOL_ERROR (err 1)" issue when the user already has the files downloaded to their system.