### PR TITLE
Prefer dedicated configs for duplicate carriers

### DIFF
--- a/scripts/carriersettings-extractor/carriersettings_extractor.py
+++ b/scripts/carriersettings-extractor/carriersettings_extractor.py
@@ -102,7 +102,12 @@ def main():
                 settings = MultiCarrierSettings()
                 settings.ParseFromString(pb.read())
                 for setting in settings.setting:
-                    assert setting.canonicalName not in all_settings
+                    if setting.canonicalName in all_settings:
+                        # Some carriers may have their own config files, as well as
+                        # a duplicate copy in others.pb. Prefer the dedicated
+                        # config if this is the case.
+                        continue
+                    
                     all_settings[setting.canonicalName] = setting
             else:
                 setting = CarrierSettings()


### PR DESCRIPTION
Pixel Android 12 builds as of SPB5.210812.002 have a duplicate carrier
config (telenor_se), which has a dedicated config file but is also
included in others.pb. This causes the script to crash:

Traceback (most recent call last):
  File ./carriersettings_extractor.py, line 51, in <module>
    assert setting.canonicalName not in all_settings
AssertionError

Prefer dedicated configs in such cases to fix the issue.